### PR TITLE
EPUB Context, required?

### DIFF
--- a/contexts/epub/README.md
+++ b/contexts/epub/README.md
@@ -2,7 +2,7 @@
 
 | Name  | URI | Description | Required? |
 | ---- | ----------- | ------------- | --------- |
-EPUB Context | https://readium.org/webpub-manifest/contexts/epub/context.jsonld  | EPUB specific metadata | Yes |
+EPUB Context | https://readium.org/webpub-manifest/contexts/epub/context.jsonld  | EPUB specific metadata | No |
 
 ## Rendition Properties
 


### PR DESCRIPTION
Fixes what appears to be inconsistent info for the `required` column vs parent page.
https://readium.org/webpub-manifest/contexts/