### PR TITLE
rename original-length to originalLength

### DIFF
--- a/extensions/epub.md
+++ b/extensions/epub.md
@@ -70,7 +70,7 @@ The Encryption Object has the following keys:
 | ----- | --------- | -------- | --------- |
 | [algorithm](#algorithm)  | Identifies the algorithm used to encrypt the resource.  | URI  | Yes |
 | [compression](#compression)  | Compression method used on the resource.  | String  | No |
-| [original-length](#original-length)  | Original length of the resource in bytes before compression and/or encryption. | Integer  | No |
+| [originalLength](#originalLength)  | Original length of the resource in bytes before compression and/or encryption. | Integer  | No |
 | [profile](#profile)  | Identifies the encryption profile used to encrypt the resource.  | URI  | No |
 | [scheme](#scheme)  | Identifies the encryption scheme used to encrypt the resource.  | URI  | No |
 
@@ -100,7 +100,7 @@ The Encryption Object has the following keys:
       "profile": "http://readium.org/lcp/basic-profile",
       "algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
       "compression": "deflate",
-      "original-length": 13810
+      "originalLength": 13810
     }
   }
 }

--- a/schema/extensions/epub/properties.schema.json
+++ b/schema/extensions/epub/properties.schema.json
@@ -46,7 +46,7 @@
           "description": "Compression method used on the resource",
           "type": "string"
         },
-        "original-length": {
+        "originalLength": {
           "description": "Original length of the resource in bytes before compression and/or encryption",
           "type": "integer"
         },


### PR DESCRIPTION
For the sake of consistency, properties are written using camelCase, and property values are hyphenated.

This is a simplified version of a previous PR, which was about original-length and media-overlay. We're discussing getting rid of the media-overlay property, so we'll wait for this one. 

About the impact of such a change, @mickael-menu said: "Not much impact, we just have to parse original-length as a fallback for backward compatibility. We use the in-memory model in the app so the serialization is not used for that."