### PR TITLE
Clarify kbps is expected for bitrate

### DIFF
--- a/extensions/audiobook.md
+++ b/extensions/audiobook.md
@@ -93,7 +93,7 @@ In addition to the normal requirements of a `readingOrder`, all Link Objects hav
  - they <strong class="rfc">must</strong> point strictly to audio resources
  - they <strong class="rfc">must</strong> include a `duration` term that provides the duration in seconds of each individual audio resource
 
-In addition, all Link Objects <strong class="rfc">should</strong> also include the `bitrate` whenever possible.
+In addition, all Link Objects <strong class="rfc">should</strong> also include the `bitrate` (in `kbps`) whenever possible.
 
 ## 3. Alternate Audio Resources
 


### PR DESCRIPTION
This slightly improves consistency in the audiobook profile doc, as seconds are explicitly mentioned for `duration` but kbps was not for `bitrate`. 

To be fair you can find it in the description in  `link.schema.json` but I was recently caught off-guard by a popular JS module/lib expressing bitrate in bytes per second so I think it doesn’t hurt to add it in the markdown doc. 