### PR TITLE
Update default layout logo link behavior

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,9 +19,15 @@
   <body>
     <div class="container-lg px-3 my-5 markdown-body">
 
-      <a href="https://readium.org">
+      {% if page.url == "/" %}
+      <a href="/" title="Back to the Readium project site.">
         <img src="https://readium.org/assets/logos/readium-logo.png" alt="Readium Logo" width="250">
       </a>
+      {% else %}
+      <a href="/webpub-manifest/" title="Back to the index page.">
+        <img src="https://readium.org/assets/logos/readium-logo.png" alt="Readium Logo" width="250">
+      </a>
+      {% endif %}
 
       {{ content }}
 


### PR DESCRIPTION
If the page is the jekyll site home page, link to the root project site.
If the page is a sub-page, link to the jekyll site home page.

I think this is a UX improvement for anyone reading our documentation.
When I click on a page, and then I click on the logo; I'm expecting that I'll go back to the root of the documentation site, not the main Readium site.