### PR TITLE
Removal of comma after 'type': 'Boolean' to resolve Ruby JSON parser …

### DIFF
--- a/schema/extensions/presentation/metadata.schema.json
+++ b/schema/extensions/presentation/metadata.schema.json
@@ -9,7 +9,7 @@
       "properties": {
         "clipped": {
           "description": "Specifies whether or not the parts of a linked resource that flow out of the viewport are clipped.",
-          "type": "boolean",
+          "type": "boolean"
         },
         "continuous": {
           "description": "Indicates if consecutive linked resources from the `reading order` should be handled in a continuous or discontinuous way.",


### PR DESCRIPTION
…error.

https://github.com/readium/webpub-manifest/blob/92959d378d892cbbb7dedf2bb165815da1e92ea7/schema/extensions/presentation/metadata.schema.json#L12
