### PR TITLE
Update of the Divina spec, viewportRatio, video and wording

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -4,6 +4,7 @@
 | ----- | ------------ |
 | [Encryption](encryption.md) | Property which conveys to User Agents how a given resource has been encrypted. |
 | [Presentation Hints](presentation.md) | Metadata and properties which convey to User Agents how a given publication should be presented. |
+| [Transitions](transitions.md) | Properties defining transition effects that may appear between resources in a Divina publication. |
 
 ## Registering a module
 

--- a/modules/presentation.md
+++ b/modules/presentation.md
@@ -1,6 +1,6 @@
 # Presentation Hints
 
-The Presentation Hints extension defines a number of hints for User Agents about the way content <strong class="rfc">should</strong> be presented to the user.
+The Presentation Hints module defines a number of hints for User Agents about the way content <strong class="rfc">should</strong> be presented to the user.
 
 ## 1. Presentation Hints in `metadata`
 
@@ -10,8 +10,9 @@ In order to provide publication-wide Presentation Hints, this extension introduc
 | ----- | --------- | -------- |
 | `presentation` | Publication-wide presentation hints. | Object |
 
-The following elements <strong class="rfc">may</strong> be included in `presentation`:
+The following elements <strong class="rfc">may</strong> be included in the `presentation` object:
 
+- [`viewportRatio`](#viewportratio)
 - [`clipped`](#clipped)
 - [`continuous`](#continuous)
 - [`fit`](#fit)
@@ -33,15 +34,76 @@ The following elements <strong class="rfc">may</strong> be included in `properti
 
 ## 3. Properties
 
+### viewportRatio
+
+By default, the viewport is the whole available screen space. The optional `viewportRatio` object constrains the viewport, possibly forcing the apparition of bar scopes.
+
+This specification defines the following keys for this JSON object:
+
+| Key  | Definition | Format | Default | Required? |
+| ---- | -----------| -------| --------| ----------|
+| `constraint`  | Type of constraint  | `exact`, `min`, `max` | `exact` | Yes |
+| `aspectRatio` | Aspect ratio | `X:Y`, where X and Y are numbers (e.g. "16:9") | `exact` | Yes |
+
+*In this example, resources fit a 16:9 viewport. The publication behaves like a turbomedia. Vertical or horizontal barscopes may appear in the screen ratio is not 16:9. *
+
+```json
+"metadata": {
+  "readingProgression": "ltr",
+  "presentation": {
+    "continuous": false,
+    "viewportRatio": {
+      "constraint": "exact",
+      "aspectRatio": "16:9"
+    }
+  }
+}
+```
+
+*In this example, resources fit a viewport which fills the total height of the screen and has a maximum ratio of 1:2 (one unit / width for two units / height). The publication behaves like a webtoon. Vertical barscopes will appear if the screen ratio is larger than 1:2, which is especially the case on a desktop screen (where screen orientation has no meaning). Horizontal barscopes will never show.*
+
+```json
+"metadata": {
+  "readingProgression": "ttb",
+  "presentation": {
+    "continuous": true,
+    "orientation": "portrait",
+    "overflow": "scrolled",
+    "fit": "width",
+    "viewportRatio": {
+      "constraint": "max",
+      "aspectRatio": "1:2"
+    }
+  }
+}
+```
+
+*In this example, resources fit a viewport which fills the total width of the screen and has a minimum ratio of 2:1 (two units / width for one unit / height). The publication behaves like an infinite horizontal scroll. Horizontal barscopes will appear if the screen ratio is smaller than 2:1, which is especially the case on a tablet in portrait mode. Vertical barscopes will never show.*
+
+```json
+"metadata": {
+  "readingProgression": "ltr",
+  "presentation": {
+    "continuous": true,
+    "overflow": "scrolled",
+    "fit": "width",
+    "viewportRatio": {
+      "constraint": "min",
+      "aspectRatio": "2:1"
+    }
+  }
+}
+```
+
 ### clipped
 
 The `clipped` property is meant to adapt visual resources to any given viewport ratio. The clipped areas <strong class="rfc">must not</strong> contain information which are mandatory for the comprehension of the resource. 
 
 | Key   | Semantics | Type     | Values    | Default |
 | ----- | --------- | -------- | --------- | ------- |
-| `clipped` | Specifies whether or not the parts of a linked resource that flow out of the viewport are clipped.  | Boolean  | `true` or `false` | `false` |
+| `clipped` | Specifies whether or not the parts of a resource that flow out of the viewport are clipped.  | Boolean  | `true` or `false` | `false` |
 
-*In this example, resources are handled in a discontinuous way and each resource is scaled to fit the viewport height and clipped to fit different viewport widths. It behaves like turbomedia.*
+*In this example, resources are handled in a discontinuous way and each resource is scaled to fit the viewport height and clipped to fit different viewport widths. The publication behaves like a turbomedia.*
 
 ```json
 "metadata": {
@@ -74,7 +136,7 @@ The `clipped` property is meant to adapt visual resources to any given viewport 
 
 | Key   | Semantics | Type     | Values    | Default |
 | ----- | --------- | -------- | --------- | ------- |
-| `continuous` | Indicates if consecutive linked resources from the `readingOrder` should be handled in a continuous or discontinuous way.  | Boolean  | `true` or `false`  | `true` |
+| `continuous` | Indicates if consecutive resources from the `readingOrder` should be handled in a continuous or discontinuous way.  | Boolean  | `true` or `false`  | `true` |
 
 *In this example, the user will not experience discontinuities between the different resources*
 
@@ -90,7 +152,7 @@ The `clipped` property is meant to adapt visual resources to any given viewport 
 
 | Key   | Semantics | Type     | Values    | Default |
 | ----- | --------- | -------- | --------- | ------- |
-| `fit` | Specifies constraints for the presentation of a linked resource within the viewport.  | String  | `contain`, `cover`, `width` or `height` | `contain` |
+| `fit` | Specifies constraints for the presentation of a resource within the viewport.  | String  | `contain`, `cover`, `width` or `height` | `contain` |
 
 | Value   | Definition |
 | ------- | ---------- |
@@ -99,7 +161,7 @@ The `clipped` property is meant to adapt visual resources to any given viewport 
 | `width`  |  The content is centered and scaled to fit the viewport width. |
 | `height` |  The content is centered and scaled to fit the viewport height. |
 
-*In this example, resources are handled in a continuous way, the content is scrollable on the vertical axis and each resource fits the viewport width. It behaves like a webtoon.*
+*In this example, resources are handled in a continuous way, the content is scrollable on the vertical axis and each resource fits the viewport width. The publication behaves like a webtoon.*
 
 ```json
 "metadata": {
@@ -111,6 +173,7 @@ The `clipped` property is meant to adapt visual resources to any given viewport 
   }
 }
 ```
+
 *In this example, a specific resource is scaled to fit the viewport.*
 
 ```json
@@ -129,7 +192,7 @@ The `clipped` property is meant to adapt visual resources to any given viewport 
 
 | Key   | Semantics | Type     | Values    | Default |
 | ----- | --------- | -------- | --------- | ------- |
-| `orientation` | Suggested orientation for the device when displaying the linked resource.  | String  | `landscape`, `portrait` or `auto`  | `auto` |
+| `orientation` | Suggested orientation for the device when displaying the resource.  | String  | `landscape`, `portrait` or `auto`  | `auto` |
 
 The `orientation` property is mostly relevant for resources with fixed dimensions (images, videos), where the orientation has an actual impact on how the resource is displayed.
 
@@ -160,7 +223,7 @@ The `orientation` property is mostly relevant for resources with fixed dimension
 
 | Key   | Semantics | Type     | Values    | Default |
 | ----- | --------- | -------- | --------- | ------- |
-| `overflow` |  Indicates if the overflow of linked resources from the `readingOrder` or `resources` should be handled using dynamic pagination or scrolling.  | String  | `paginated`, `scrolled` or `auto` | `auto` |
+| `overflow` |  Indicates if the overflow of resources from the `readingOrder` or `resources` should be handled using dynamic pagination or scrolling.  | String  | `paginated`, `scrolled` or `auto` | `auto` |
 
 
 | Value   | Definition |
@@ -187,7 +250,7 @@ The `page` property is meant to provide a hint to Use Agents that rely on synthe
 
 | Key   | Semantics | Type     | Values    | Default |
 | ----- | --------- | -------- | --------- | ------- |
-| `page` | Indicates how the linked resource should be displayed in a reading environment that displays synthetic spreads.  | String  | `left`, `right` or `center` | None |
+| `page` | Indicates how the resource should be displayed in a reading environment that displays synthetic spreads.  | String  | `left`, `right` or `center` | None |
 
 *In this example, the first page should be displayed of the left of a synthetic spread, the second page on the right.*
 
@@ -214,7 +277,7 @@ The `page` property is meant to provide a hint to Use Agents that rely on synthe
 
 | Key   | Semantics | Type     | Values    | Default |
 | ----- | --------- | -------- | --------- | ------- |
-| `spread` | Indicates the condition to be met for the linked resource to be rendered within a synthetic spread. | String  | `landscape`, `both`, `none` or `auto`  | `auto` |
+| `spread` | Indicates the condition to be met for the resource to be rendered within a synthetic spread. | String  | `landscape`, `both`, `none` or `auto`  | `auto` |
 
 | Value   | Definition |
 | ------- | ---------- |

--- a/modules/transitions.md
+++ b/modules/transitions.md
@@ -1,5 +1,9 @@
 # Transitions
 
+The Transitions Module defines transition effects that may appear between resources in a Divina publication.
+
+### transitionForward, transitionBackward
+
 In the reading order of a publication, Link Objects <strong class="rfc">may</strong> contain the following additional properties: 
 
 | Key   | Semantics | Type     | Values    | 
@@ -7,9 +11,7 @@ In the reading order of a publication, Link Objects <strong class="rfc">may</str
 | [transitionForward](#transitionForward-transitionBackward) | Describes the transition to be applied when moving FROM the previous resource TO current resource in reading order  | Transition Object | See [Transition Object](#the-transition-object)  | 
 | [transitionBackward](#transitionForward-transitionBackward) | Describes the transition to be applied when moving FROM the current resource TO the previous resource in reading order  | Transition Object | See [Transition Object](#the-transition-object)  | 
 
-### transitionForward, transitionBackward
-
-Keep in mind that a forward transition is placed on the TARGET resource of the transition.
+Note: Keep in mind that a forward transition is placed on the TARGET resource of the transition.
 
 ### The Transition Object
 

--- a/profiles/divina.md
+++ b/profiles/divina.md
@@ -216,16 +216,15 @@ As an alternative, the manifest may also be included into an EPUB 3 publication,
 
 ### Level 0
 
-* Support for the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) with bitmap images in `readingOrder`
-* Support for [presentation hints](../modules/presentation.md)
-* Support for [alternate resources](#3-alternate-resources)
-
+* Support for the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) with bitmap images in the `readingOrder`.
+* Support for [presentation hints](../modules/presentation.md).
+* Support for [alternate resources](#3-alternate-resources). 
 
 ### Level 1
 
 * Support for video resources in the `readingOrder`. 
-* Support for [guided navigation](#4-guided-navigation)
-* Support for [transitions](../modules/transitions.md)
+* Support for [guided navigation](#4-guided-navigation).
+* Support for [transitions](../modules/transitions.md).
 
 ### Level 2
 

--- a/profiles/divina.md
+++ b/profiles/divina.md
@@ -85,13 +85,13 @@ In addition, all Link Objects <strong class="rfc">should</strong> include `width
 
 ## 3. Alternate Resources
 
-In order to provide multiple variants of the same resource, Link Objects in the `readingOrder` <strong class="rfc">may</strong> rely on the `alternate` key.
+Alternate resources are part of the core model of Readium web publications. This section describes the use of alternate resources in the scope of the Divina profile.
 
 All Link Objects present in the `alternate` array:
 
-- <strong class="rfc">must</strong> indicate their media-type using `type`
-- <strong class="rfc">should</strong> indicate their dimensions using `height` and `width`
-- <strong class="rfc">may</strong> target a different language using `language`
+- <strong class="rfc">must</strong> indicate their media-type using `type`.
+- <strong class="rfc">should</strong> indicate their dimensions using `height` and `width`, plus `duration`in the case of video resources. 
+- <strong class="rfc">may</strong> target a different language using `language`.
 
 *Example 1: A resource available in JPEG and WebP*
 
@@ -112,12 +112,12 @@ All Link Objects present in the `alternate` array:
 
 ```json
 {
-  "href": "http://example.org/page1.jpeg", 
+  "href": "http://example.org/page2-fr.jpeg", 
   "type": "image/jpeg",
   "language": "fr",
   "alternate": [
     {
-      "href": "http://example.org/page1-jp.jpeg", 
+      "href": "http://example.org/page2-jp.jpeg", 
       "type": "image/jpeg",
       "language": "jp"
     }
@@ -129,16 +129,36 @@ All Link Objects present in the `alternate` array:
 
 ```json
 {
-  "href": "http://example.org/page1.jpeg", 
+  "href": "http://example.org/page3-hires.jpeg", 
   "type": "image/jpeg",
-  "width": 546,
-  "height": 760,
+  "width":  1092,
+  "height": 1520,
   "alternate": [
     {
-      "href": "http://example.org/page1-high.jpeg", 
+      "href": "http://example.org/page3-lores.jpeg", 
       "type": "image/jpeg",
-      "width": 1092,
-      "height": 1520
+      "width":  546,
+      "height": 760 
+    }
+  ]
+}
+```
+
+*Example 4: A video resource and its image fallback*
+
+```json
+{
+  "href": "http://example.org/page4.mp4", 
+  "type": "video/mp4",
+  "width": 1024,
+  "height": 576,
+  "duration": 2437,
+  "alternate": [
+    {
+      "href": "http://example.org/page4.jpeg", 
+      "type": "image/jpeg",
+      "width": 1024,
+      "height": 576
     }
   ]
 }
@@ -197,13 +217,14 @@ As an alternative, the manifest can also be added to an EPUB ([as defined in the
 
 ### Level 0
 
-* Support for the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) with bitmap images in `readingOrder`
+* Support for the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) with bitmap images in the `readingOrder`
 * Support for [presentation hints](presentation.md)
 * Support for [alternate resources](#3-alternate-resources)
 
 
 ### Level 1
 
+* Support for video resources in the `readingOrder`. 
 * Support for [guided navigation](#4-guided-navigation)
 * Support for [transitions](../modules/transitions.md)
 
@@ -213,7 +234,7 @@ As an alternative, the manifest can also be added to an EPUB ([as defined in the
 
 ## Appendix B. Examples
 
-*Example 5: A manga is a DiViNa where images are presented sequentially from right-to-left with a discontinuity between images that are not in the same spread*
+*Example 5: A manga is a Divina publication where images are presented sequentially from right-to-left with a discontinuity between images that are not in the same spread*
 
 
 ```json
@@ -249,7 +270,7 @@ As an alternative, the manifest can also be added to an EPUB ([as defined in the
 }
 ```
 
-*Example 6: A webtoon is a DiViNa where images are scrolled in a single continuous strip of content*
+*Example 6: A webtoon is a Divina publication where images are scrolled vertically in a single continuous strip of content*
 
 
 ```json
@@ -260,9 +281,14 @@ As an alternative, the manifest can also be added to an EPUB ([as defined in the
     "conformsTo": "https://readium.org/webpub-manifest/profiles/divina",
     "readingProgression": "ttb",
     "presentation": {
+      "orientation": "portrait",
+      "continuous": true,
       "overflow": "scrolled",
       "fit": "width",
-      "continuous": true
+      "viewportRatio": {
+        "constraint": "max",
+        "aspectRatio": "1:2"
+      }
     }
   },
   "readingOrder": [


### PR DESCRIPTION
The essential update is the addition of the `viewportRatio` property in the the `presentation` object, with some useful examples. This property had been discussed at length, approved, implemented into the Divina player but not inserted into the spec. This is now done. 

Another addition is the support of video resources at *Level 1* of the Divina profile. The first Divina publication, "Bravery", already makes use of this feature for a few animated pages  (e.g. page 28, 29 and 30).

The other evolutions are cosmetic:
- a reference to the transitions module added to the list of modules (the module was already present)
- a minor cleanup of the spec of the transitions module. 
- the simplification of "linked resources" to "resources" in the spec of presentation hints
-  a minor cleanup of the section about alternate resources in the divina spec and samples.