### PR TITLE
Separate packaging spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It is the primary exchange format used in the [Readium Architecture](https://rea
 * [6. Table of Contents](#6-table-of-contents)
 * [7. Cover](#7-cover)
 * [8. Extensibility](#8-extensibility)
-* [9. Package](#9-package)
+* [9. Packaging a Readium Web Publication](#9-packaging-a-readium-web-publication)
 * [Appendix A. JSON Schema](#appendix-a-json-schema)
 
 ## Example
@@ -352,33 +352,11 @@ The initial registry, contains the following profiles:
 | [Digital Visual Narratives Profile](profiles/divina.md) | Defines a dedicated profile for visual narratives (comics, manga and bandes dessinées). |
 | [EPUB Profile](profiles/epub.md) | Additional metadata and collection roles for representing EPUB publications. |
 
-## 9. Package
+## 9. Packaging a Readium Web Publication
 
-The Readium Web Publication Manifest is primarily meant to be distributed unpackaged on the Web.
+A Readium Web Publication is often distributed unpackaged on the Web, but it also may be packaged for easy distribution as a single file. A Readium Web Publication Manifest may also be included in an EPUB 3 publication and therefore directly reference media resources present in the package. 
 
-That said, a Readium Web Publication Manifest <strong class="rfc">may</strong> be included in an EPUB 3.2.
-
-If a Readium Web Publication Manifest is included in an EPUB, the following restrictions apply:
-
-- the manifest document <strong class="rfc">must</strong> be named `manifest.json` and <strong class="rfc">must</strong> appear at the top level of the container
-- the OPF of the primary rendition <strong class="rfc">must</strong> include a link to the manifest where the link relation is set to `alternate`
-
-
-*Example 9: Reference to a manifest in an OPF*
-
-```xml
-<link rel="alternate" 
-      href="manifest.json" 
-      media-type="application/webpub+json" />
-```
-
-In addition to the EPUB format, a Readium Web Publication <strong class="rfc">may</strong> also be distributed as a separate package where:
-
-- its media type <strong class="rfc">must</strong> be `application/webpub+zip`
-- its file extension <strong class="rfc">must</strong> be `.webpub`
-- the package itself <strong class="rfc">must</strong> be a ZIP archive and follow the restrictions expressed in [ISO/IEC 21320-1:2015](http://standards.iso.org/ittf/PubliclyAvailableStandards/c060101_ISO_IEC_21320-1_2015.zip)
-- the manifest <strong class="rfc">must</strong> be named `manifest.json` and <strong class="rfc">must</strong> appear at the top level of the package
-- a publication where any resource is encrypted using a DRM <strong class="rfc">must</strong> use a different media type and file extension
+To achieve both goals, this specification defines the [Readium Packaging Format (RPF)](./packaging.md).
 
 ## Appendix A. JSON Schema
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It is the primary exchange format used in the [Readium Architecture](https://rea
 * [6. Table of Contents](#6-table-of-contents)
 * [7. Cover](#7-cover)
 * [8. Extensibility](#8-extensibility)
-* [9. Packaging a Readium Web Publication](#9-packaging-a-readium-web-publication)
+* [9. Packaging a Readium Web Publication](#9-packaging)
 * [Appendix A. JSON Schema](#appendix-a-json-schema)
 
 ## Example
@@ -352,11 +352,9 @@ The initial registry, contains the following profiles:
 | [Digital Visual Narratives Profile](profiles/divina.md) | Defines a dedicated profile for visual narratives (comics, manga and bandes dessinées). |
 | [EPUB Profile](profiles/epub.md) | Additional metadata and collection roles for representing EPUB publications. |
 
-## 9. Packaging a Readium Web Publication
+## 9. Packaging
 
-A Readium Web Publication is often distributed unpackaged on the Web, but it also may be packaged for easy distribution as a single file. A Readium Web Publication Manifest may also be included in an EPUB 3 publication and therefore directly reference media resources present in the package. 
-
-To achieve both goals, this specification defines the [Readium Packaging Format (RPF)](./packaging.md).
+A Readium Web Publication may be distributed unpackaged on the Web, but it may also be packaged for easy distribution as a single file. To achieve this goal, this specification defines the [Readium Packaging Format (RPF)](./packaging.md).
 
 ## Appendix A. JSON Schema
 

--- a/packaging.md
+++ b/packaging.md
@@ -62,17 +62,30 @@ These resource files <strong class="rfc">may</strong> be in any location descend
 Contents within the Package <strong class="rfc">must</strong> reference these resources via [relative-URL strings](https://url.spec.whatwg.org/#relative-url-string).
 
 
-## 7. Hybrid EPUB + RPF Packages
+## 6. Hybrid EPUB 3 + RPF Packages
+
+As an alternative to the creation of a pure RPF package, the manifest may also be included into an EPUB 3 publication and directly reference the media resources present in the package.
+
+An RPF compliant application will therefore be able to process the file as an RPF package, while an EPUB 3 compliant application will process it as a standard EPUB 3 publication. 
 
 If a Readium Web Publication Manifest is included in an EPUB 3 file, the following restriction apply:
 
-- The OPF of the primary rendition <strong class="rfc">must</strong> include a link to the manifest where the link relation is set to `alternate`
+- The EPUB 3 package document <strong class="rfc">must</strong> include a link to the Readium Web Publication Manifest, where the link relation is set to `alternate`
+- The EPUB 3 package document <strong class="rfc">must</strong> include in its `manifest` structure a reference to the Readium Web Publication Manifest.
+- - The EPUB 3 package document <strong class="rfc">must</strong> include in its `manifest` structure a reference to any resource (e.g. sound) used in the Readium Web Publication Manifest.
 
 
 *Example 1: Reference to a Manifest file in an EPUB 3 OPF structure*
 
 ```xml
-<link rel="alternate" 
-      href="manifest.json" 
-      media-type="application/webpub+json" />
+<metadata>
+      <link rel="alternate" 
+            href="manifest.json" 
+            media-type="application/webpub+json" />
+</metadata>
+...
+<manifest>
+    <item href="manifest.json" media-type="application/webpub+json" id="rwpm"/>
+    ...
+</manifest>
 ```

--- a/packaging.md
+++ b/packaging.md
@@ -1,0 +1,78 @@
+# Readium Packaging Format (RPF)
+
+This specification defines a file format for packaging into a single-file container the set of related resources and associated metadata that comprise a Readium Web Publication.
+
+**Editors:**
+
+* Hadrien Gardeur ([De Marque](http://www.demarque.com))
+* Laurent Le Meur ([EDRLab](http://www.edrlab.org))
+
+**Participate:**
+
+* [GitHub readium/webpub-manifest](https://github.com/readium/webpub-manifest)
+* [File an issue](https://github.com/readium/webpub-manifest/issues)
+
+
+## 1. Introduction
+
+A Readium Web Publication is often distributed unpackaged on the Web, but it also may be packaged for easy distribution as a single file. 
+
+A Readium Web Publication Manifest may also be included in an EPUB 3 publication and therefore directly reference media resources present in the package. This method paves the way to hybrid publications, which can e.g. be both valid EPUB 3 and Divina publications. When played in Divina compliant software, users will benefit from advanced features like transitions, guided navigation, layers, sound effects etc. which are not available in the EPUB 3 format.   
+
+## 2. Terminology 
+
+<dl>
+ <dt id="codec">Codec content types</dt>
+ <dd>Content types that have intrinsic binary format qualities, such as video and audio media types which are already designed for optimum compression, or which provide optimized streaming capabilities.</dd>
+ <dt id="non-codec">Non-Codec content types</dt>
+ <dd>Content types that benefit from compression due to the nature of their internal data structure, such as file formats based on character strings (for example, HTML, CSS, etc.).</dd>
+ <dt id="package">Package</dt>
+ <dd>Single-file container for the set of constituent resources and associated metadata that comprise a digital publication.</dd>
+ <dt id="root-directory">Root Directory</dt>
+ <dd>Base directory of the Package file system.</dd>
+</dl>
+
+## 3. Packaging format
+
+For packaging the set of constituent resources and associated metadata that comprise a digital publication, this specification uses the ZIP format as specified in [ISO/IEC 21320-1:2015](http://standards.iso.org/ittf/PubliclyAvailableStandards/c060101_ISO_IEC_21320-1_2015.zip) and [zip](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).
+
+In the absence of values defined at the level of a Readium Web Publication [profile](profiles/):
+
+- The media type <strong class="rfc">must</strong> be `application/webpub+zip`
+- The file extension <strong class="rfc">must</strong> be `.webpub`
+
+A publication where any resource is encrypted using a DRM <strong class="rfc">must</strong> use a different media type and file extension.
+
+## 4. Compression of resources
+
+When stored in a Package, resources with [Non-Codec content types](#non-codec) <strong class="rfc">should</strong> be compressed and the Deflate compression algorithm MUST be used. This practice ensures that file entries stored in the Package have a smaller size.
+
+Resources with [Codec content types](#codec) <strong class="rfc">should</strong> be stored without compression. In such case, compression would introduce unnecessary processing overhead at production time (especially with large resource files) and would impact audio/video playback performance at consumption time.
+
+## 5. File Structure
+
+A [Package](#package) <strong class="rfc">must</strong> include in its [Root Directory](#root-directory) a file named `manifest.json`, which <strong class="rfc">must</strong> be in the format defined for [Readium Web Publication Manifests](README.md).
+
+The contents of `manifest.json` <strong class="rfc">must</strong> not be encrypted.
+
+A Package <strong class="rfc">must</strong> also include all resources within the bounds of the digital publication, i.e. the finite set of resources obtained from the union of resources listed in the `reading order` and `resources` Link Arrays of the Readium Web Publication Manifest.
+
+These resource files <strong class="rfc">may</strong> be in any location descendant from the Root Directory, or in the Root Directory itself.
+
+Contents within the Package <strong class="rfc">must</strong> reference these resources via [relative-URL strings](https://url.spec.whatwg.org/#relative-url-string).
+
+
+## 7. Hybrid EPUB + RPF Packages
+
+If a Readium Web Publication Manifest is included in an EPUB 3 file, the following restriction apply:
+
+- The OPF of the primary rendition <strong class="rfc">must</strong> include a link to the manifest where the link relation is set to `alternate`
+
+
+*Example 1: Reference to a Manifest file in an EPUB 3 OPF structure*
+
+```xml
+<link rel="alternate" 
+      href="manifest.json" 
+      media-type="application/webpub+json" />
+```

--- a/profiles/audiobook.md
+++ b/profiles/audiobook.md
@@ -124,11 +124,11 @@ All Link Objects present in the `alternate` array:
 - <strong class="rfc">must</strong> reference audio resources of the same duration as the top-level Link Object
 - <strong class="rfc">must not</strong> include the following keys: `title`, `duration` or `templated`
 
-## 4. Package
+## 4. Packaging
 
-In order to facilitate distribution, both manifest and audio files can also be distributed using a package based on [the requirements expressed for the Readium Web Publication Manifest](https://readium.org/webpub-manifest#9-package).
+An Audiobook publication may be distributed unpackaged on the Web, but it may also be packaged for easy distribution as a single file. To achieve this goal, this specification defines the [Readium Packaging Format (RPF)](./packaging.md).
 
-To maximize compatibility with audio-only apps, the package for an audiobook profile has its own file extension and media-type:
+To maximize compatibility with dedicated apps, such a package has its own file extension and media-type:
 
 - its file extension <strong class="rfc">must</strong> be `.audiobook`
 - its media type <strong class="rfc">must</strong> be `application/audiobook+zip`

--- a/profiles/divina.md
+++ b/profiles/divina.md
@@ -62,7 +62,7 @@
 
 ## Introduction
 
-The goal of this document is to provide a profile dedicated to visual narratives for the [Readium Web Publication Manifest](https://readium.org/webpub-manifest).
+The goal of this specification is to provide a profile dedicated to visual narratives for the [Readium Web Publication Manifest](https://readium.org/webpub-manifest).
 
 This profile relies on:
 
@@ -182,15 +182,14 @@ This current draft does not cover guided navigation over alternate versions of e
 
 ## 5. Packaging
 
-In order to facilitate distribution, both manifest and images can also be distributed using a package based on [the requirements expressed for the Readium Web Publication Manifest](https://readium.org/webpub-manifest#9-package).
+A Divina publication may be distributed unpackaged on the Web, but it may also be packaged for easy distribution as a single file. To achieve this goal, this specification defines the [Readium Packaging Format (RPF)](./packaging.md).
 
-To maximize compatibility with dedicated apps, the package for this profile has its own file extension and media-type:
+To maximize compatibility with dedicated apps, such a package has its own file extension and media-type:
 
 - its file extension <strong class="rfc">must</strong> be `.divina`
 - its media type <strong class="rfc">must</strong> be `application/divina+zip`
 
-As an alternative, the manifest can also be added to an EPUB ([as defined in the core specification](https://readium.org/webpub-manifest/#9-package)) or a CBZ file at the same well-known location (`manifest.json` at the root of the package).
-
+As an alternative, the manifest may also be included into an EPUB 3 publication, an hybrid solution also specified in the [Readium Packaging Format (RPF)](./packaging.md) specification. This approach allows a publisher to create EPUB 3 fixed layout comics which are enriched by transitions, guided navigation, sounds etc. accessible via Divina compliant applications.  
 
 
 ## Appendix A. Compliance Levels

--- a/profiles/divina.md
+++ b/profiles/divina.md
@@ -146,7 +146,7 @@ All Link Objects present in the `alternate` array:
 
 ## 4. Guided Navigation
 
-In addition to having [a table of contents](https://readium.org/webpub-manifest/#5-table-of-contents), a visual narrative <strong class="rfc">may</strong> also provide guided navigation where each reference is either:
+In addition to having [a table of contents](https://readium.org/webpub-manifest/#6-table-of-contents), a visual narrative <strong class="rfc">may</strong> also provide guided navigation where each reference is either:
 
 - pointing directly to a resource (`image1.jpg`)
 - or to a fragment of a resource using [Media Fragments](https://www.w3.org/TR/media-frags) (`image1.jpg#xywh=160,120,320,240`)

--- a/profiles/divina.md
+++ b/profiles/divina.md
@@ -197,7 +197,7 @@ As an alternative, the manifest may also be included into an EPUB 3 publication,
 ### Level 0
 
 * Support for the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) with bitmap images in `readingOrder`
-* Support for [presentation hints](presentation.md)
+* Support for [presentation hints](../modules/presentation.md)
 * Support for [alternate resources](#3-alternate-resources)
 
 


### PR DESCRIPTION
We talked about it before, it is better to provide a separate document for the packaging spec. Its content is more or less a copy of what was in the webpub-manifest core spec before. 

Feedback welcome.