### PR TITLE
a11y metadata proposal

### DIFF
--- a/schema/a11y.schema.json
+++ b/schema/a11y.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://readium.org/webpub-manifest/schema/a11y.schema.json",
+  "title": "Accessibility Object",
+  "type": "object",
+  "properties": {
+    "conformsTo": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "format": "uri",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "certification": {
+      "type": "object",
+      "properties": {
+        "certifier": {
+          "type": "string"
+        },
+        "credential": {
+          "type": "string"
+        },
+        "report": {
+          "type": [
+            "string",
+            "array"
+          ],
+          "format": "uri",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "accessMode": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "auditory",
+          "chartOnVisual",
+          "chemOnVisual",
+          "colorDependent",
+          "mathOnVisual",
+          "tactile",
+          "textOnVisual",
+          "textual",
+          "visual"
+        ]  
+      }
+    },
+    "accessModeSufficient": {
+      "type": "array",
+      "items": {
+        "type": [
+          "array",
+          "string"
+        ],
+        "if": {
+          "type": "string"
+        },
+        "then": {
+          "enum": [
+            "auditory",
+            "tactile",
+            "textual",
+            "visual"
+          ],
+        },
+        "items": {
+          "type": "string",
+          "enum": [
+            "auditory",
+            "tactile",
+            "textual",
+            "visual"
+          ]
+        }
+      }
+    },
+    "feature": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hazard": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schema/metadata.schema.json
+++ b/schema/metadata.schema.json
@@ -26,8 +26,14 @@
     "title": {
       "$ref": "language-map.schema.json"
     },
+    "sortAs": {
+      "$ref": "language-map.schema.json"
+    },
     "subtitle": {
       "$ref": "language-map.schema.json"
+    },
+    "accessibility": {
+      "$ref": "a11y.schema.json"
     },
     "modified": {
       "type": "string",
@@ -55,9 +61,6 @@
         "pattern": "^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?<extension>[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?<privateUse>x(-[A-Za-z0-9]{1,8})+))?)|(?<privateUse2>x(-[A-Za-z0-9]{1,8})+))$"
       },
       "pattern": "^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?<extension>[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?<privateUse>x(-[A-Za-z0-9]{1,8})+))?)|(?<privateUse2>x(-[A-Za-z0-9]{1,8})+))$"
-    },
-    "sortAs": {
-      "$ref": "language-map.schema.json"
     },
     "author": {
       "$ref": "contributor.schema.json"


### PR DESCRIPTION
This draft PR contains an initial proposal for handling a11y metadata in RWPM. It only contains a JSON Schema for now.

Among the things that are still missing in the JSON schema:

- no enum for feature, we could extract https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature
- no enum for hazard, we could extract https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard

Here's also a checklist of things that need to be handled before this becomes a real PR:

- [ ] add these properties to our JSON-LD mapping document
- [ ] add these properties to our default metadata profile
- [ ] and of course, discuss this with the group and get a broad agreement on the approach and naming conventions