### PR TITLE
Update EPUB profile documentation

### DIFF
--- a/profiles/epub.md
+++ b/profiles/epub.md
@@ -20,7 +20,8 @@ This profile relies on:
 * a declaration of [conformance with this Profile](#1-declaring-conformance-with-the-epub-profile),
 * some [restrictions on the resources of the readingOrder](#2-restrictions-on-the-resources-of-the readingorder),
 * the definition of additional [collection roles](#3-collection-roles),
-* the definition of additional [Link properties](#4-link-properties),
+* the definition of an additional [metadata property](#4-metadata-properties)
+* the definition of additional [Link properties](#5-link-properties),
 * the use of the [encryption module](../modules/encryption.md).
 
 ## 1. Declaring conformance with the EPUB Profile
@@ -44,8 +45,20 @@ While EPUB itself allows SVG and other formats as long as an XHTML fallback is p
 | lov  | Identifies the collection that contains a list of videos.  | Yes  | No  |
 | pageList  | Identifies the collection that contains a list of pages.  | Yes  | No  |
 
+## 4. Metadata Properties
 
-## 4. Link Properties
+This profile defines one additional presentation hint in the Webpub metadata object: 
+
+| Key   | Semantics | Type     | Values    | 
+| ----- | --------- | -------- | --------- | 
+| [layout](#layout)  | Hint about the default layout for all resources in the publication.  | String  | `fixed` or `reflowable`  | 
+
+
+### layout
+
+The `layout` property defaults to `reflowable` for all publications conforming to the EPUB profile. Using `fixed` indicates that the document has a viewport with a fixed size. It can be overridden on a per-resource basis as well via the [link properties](#5-link-properties).
+
+## 5. Link Properties
 
 This profile defines additional Link properties: 
 
@@ -83,9 +96,7 @@ While the media type is the main way to identify the nature of a resource in a L
 
 ### layout
 
-The `layout` property defaults to `reflowable` for text resources and `fixed` for images or videos.
-
-Using `fixed` it can also indicate that an HTML document has a viewport with a fixed size.
+The `layout` property defaults to `reflowable` unless overridden for the whole publication via the `layout` presentation hint in the [metadata properties](#4-metadata-properties). Using `fixed` on an individual resource indicates that the document has a viewport with a fixed size.
 
 ```
 {


### PR DESCRIPTION
This PR adds documentation about the `metadata.presentation.layout` presentation hint to the EPUB profile. This property is already defined in the [EPUB extension schema](https://github.com/readium/webpub-manifest/blob/master/schema/extensions/epub/metadata.schema.json). 

I also removed language suggesting that the property defaults to `fixed` for images or videos. Since the EPUB extension defines that resources in the `readingOrder` can only be HTML files, the property will always default to `reflowable` unless otherwise noted by changing either the `metadata.presentation.layout` property in the Webpub Manifest, or the `properties.layout` property on the resource link itself.

One additional question: Fixed layout EPUB resources are required to have a `meta` tag indicating the viewport size: `<meta name="viewport" content="width=1200, height=900"/>`. Would it make sense to encourage those creating Webpub Manifests for FXL EPUBS to include a `height` and `width` on the link object for the FXL resource?