### PR TITLE
Remove unappropriate description of encryption.originalLength

### DIFF
--- a/modules/encryption.md
+++ b/modules/encryption.md
@@ -28,10 +28,6 @@ The only allowed value for the compression property is currently:
 | --------- | --------- | 
 | `deflate` | Deflate algorithm, as defined by the Zip specification |
 
-### originalLength
-
-The `originalLength` property <strong class="rfc">should</strong> only be present if the `compression` property is present and has a non-null value. 
-
 
 ## LCP Encrypted Resource
 


### PR DESCRIPTION
The Readium architecture makes encryption transparent to navigators. They request bytes ranging from 0 to the original content length that they generally request at first.

The specification used to recommend to set encryption.originalLength only if the resource was compressed. As encryption padding has variable size, it is useful to have the original length of stored resources too.