### PR TITLE
Add a (simple) PDF profile 

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,9 +348,10 @@ The initial registry, contains the following profiles:
 
 | Name  |  Description |
 | ----- | ------------ |
-| [Audiobook Profile](profiles/audiobook.md) | Defines a dedicated profile for audiobooks. |
-| [Digital Visual Narratives Profile](profiles/divina.md) | Defines a dedicated profile for visual narratives (comics, manga and bandes dessinées). |
-| [EPUB Profile](profiles/epub.md) | Additional metadata and collection roles for representing EPUB publications. |
+| [EPUB Profile](profiles/epub.md) | A profile for EPUB content transformed to Web Publications. |
+| [Audiobook Profile](profiles/audiobook.md) |  A profile for Audiobooks. |
+| [Divina Profile](profiles/divina.md) | A profile for Digital Visual Narrative publications (comics, manga and bandes dessinées). |
+| [PDF Profile](profiles/pdf.md) | A profile for PDF documents integrated into Web Publications. |
 
 ## 9. Packaging
 

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -2,9 +2,10 @@
 
 | Name  |  Description | URI |
 | ----- | ------------ | --- |
-| [Audiobook Profile](audiobook.md) | Defines a dedicated profile for audiobooks. | [https//readium.org/webpub-manifest/profiles/audiobook](https//readium.org/webpub-manifest/profiles/audiobook) |
-| [Digital Visual Narratives Profile](divina.md) | Defines a dedicated profile for visual narratives (comics, manga and bandes dessinées). | [https//readium.org/webpub-manifest/profiles/divina](https//readium.org/webpub-manifest/profiles/divina) |
-| [EPUB Profile](epub.md) | Additional metadata and collection roles for representing EPUB publications. |[https//readium.org/webpub-manifest/profiles/epub](https//readium.org/webpub-manifest/profiles/epub) |
+| [EPUB Profile](./epub.md) | A profile for EPUB content transformed to Web Publications. | https//readium.org/webpub-manifest/profiles/epub |
+| [Audiobook Profile](./audiobook.md) | A profile for Audiobooks. | https//readium.org/webpub-manifest/profiles/audiobook |
+| [Divina Profile](./divina.md) | A profile for Digital Visual Narrative publications (comics, manga and bandes dessinées). | https//readium.org/webpub-manifest/profiles/divina |
+| [PDF Profile](./pdf.md) | A profile for PDF documents integrated into Web Publications. | https//readium.org/webpub-manifest/profiles/pdf |
 
 
 ## Registering a profile

--- a/profiles/pdf.md
+++ b/profiles/pdf.md
@@ -62,7 +62,7 @@ To declare that it conforms to the PDF Profile, a Readium Web Publication Manife
 
 ## 2. Restrictions on resources in the reading order
 
-In addition to the normal requirements of a `readingOrder`, all Link Objects <strong class="rfc">must</strong> point strictly to PDF resources (with a media type media type of value `application/pdf`), with no fragment identifier. 
+In addition to the normal requirements of a `readingOrder`, all Link Objects <strong class="rfc">must</strong> point strictly to PDF resources, with no fragment identifier. 
 
 > **Note**
 > While this specification defines the possibility to insert several PDF files into the reading order, the current versions of the Readium toolkits only support one item.

--- a/profiles/pdf.md
+++ b/profiles/pdf.md
@@ -1,0 +1,68 @@
+# PDF Profile
+
+**Editors:**
+
+* Michael Benowitz ([NYPL](https://www.nypl.org))
+* Laurent Le Meur ([EDRLab](https://www.edrlab.org))
+
+**Participate:**
+
+* [GitHub readium/webpub-manifest](https://github.com/readium/webpub-manifest)
+* [File an issue](https://github.com/readium/webpub-manifest/issues)
+
+## Example
+
+```json
+{
+  "@context": "http://readium.org/webpub-manifest/context.jsonld",
+  
+  "metadata": {
+    "@type": "http://schema.org/Book",
+    "conformsTo": "https://readium.org/webpub-manifest/profiles/pdf",
+    "title": "Moby-Dick",
+    "author": "Herman Melville",
+    "language": "en"
+  },
+
+  "links": [
+    {"rel": "self", "href": "http://example.org/manifest.json", "type": "application/webpub+json"},
+  ],
+
+  "readingOrder": [
+    {
+      "href": "http://example.org/mobydick-part1.pdf", 
+      "type": "application/pdf", 
+    },
+    {
+      "href": "http://example.org/mobydick-part2.pdf", 
+      "type": "application/pdf", 
+    }
+  ],
+  
+  "resources": [
+    {"rel": "cover", "href": "http://example.org/cover.jpeg", "type": "image/jpeg", "height": 600, "width": 300}
+  ]
+}
+```
+
+## Introduction
+
+The goal of this specification is to provide a profile of the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) dedicated to pdf documents.
+
+It is mostly used as a basis for the specification of a method for protecting PDF files using LCP, i.e. [LCP for PDF](https://readium.org/lcp-specs/notes/lcp-for-pdf.html). 
+
+This profile relies on:
+
+* a declaration of [conformance with this Profile](#1-declaring-conformance-with-the-pdf-profile),
+* some [restrictions on the resources of the reading order](#2-restrictions-on-the-resources-of-the-reading-order),
+
+## 1. Declaring conformance with the PDF Profile
+
+To declare that it conforms to the PDF Profile, a Readium Web Publication Manifest <strong class="rfc">must</strong> include a `conformsTo` key in its `metadata` section, with `https://readium.org/webpub-manifest/profiles/pdf` as value.
+
+## 2. Restrictions on resources in the reading order
+
+In addition to the normal requirements of a `readingOrder`, all Link Objects <strong class="rfc">must</strong> point strictly to PDF resources (with a media type media type of value `application/pdf`), with no fragment identifier. 
+
+> **Note**
+> While this specification defines the possibility to insert several PDF files into the reading order, the current versions of the Readium toolkits only support one item.

--- a/profiles/pdf.md
+++ b/profiles/pdf.md
@@ -47,22 +47,19 @@
 
 ## Introduction
 
-The goal of this specification is to provide a profile of the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) dedicated to pdf documents.
+The goal of this specification is to provide a profile of the [Readium Web Publication Manifest](https://readium.org/webpub-manifest) dedicated to PDF documents.
 
 It is mostly used as a basis for the specification of a method for protecting PDF files using LCP, i.e. [LCP for PDF](https://readium.org/lcp-specs/notes/lcp-for-pdf.html). 
 
 This profile relies on:
 
 * a declaration of [conformance with this Profile](#1-declaring-conformance-with-the-pdf-profile),
-* some [restrictions on the resources of the reading order](#2-restrictions-on-the-resources-of-the-reading-order),
+* a [restriction on the resources of the reading order](#2-restrictions-on-the-resources-of-the-reading-order),
 
 ## 1. Declaring conformance with the PDF Profile
 
-To declare that it conforms to the PDF Profile, a Readium Web Publication Manifest <strong class="rfc">must</strong> include a `conformsTo` key in its `metadata` section, with `https://readium.org/webpub-manifest/profiles/pdf` as value.
+To declare that it conforms to the PDF Profile, a Readium Web Publication Manifest <strong class="rfc">must</strong> include a `conformsTo` key in its `metadata` section, with `https://readium.org/webpub-manifest/profiles/pdf` as one of its value.
 
-## 2. Restrictions on resources in the reading order
+## 2. Restriction on resources in the reading order
 
 In addition to the normal requirements of a `readingOrder`, all Link Objects <strong class="rfc">must</strong> point strictly to PDF resources, with no fragment identifier. 
-
-> **Note**
-> While this specification defines the possibility to insert several PDF files into the reading order, the current versions of the Readium toolkits only support one item.


### PR DESCRIPTION
Because we need to have a PDF profile released asap, Here is a simple proposal, with a text aligned with the other profiles and no introduction of a new property, as in https://github.com/readium/webpub-manifest/pull/88. 

If we agree about the addition of a `start` property (which means that every Readium toolkits will be ready to implement it), we'll update this profile accordingly. 

