### PR TITLE
Added altIdentifier to default context and JSON Schema

### DIFF
--- a/contexts/default/README.md
+++ b/contexts/default/README.md
@@ -55,6 +55,26 @@ A Web Publication Manifest <span class="rfc">should</span> contain an identifier
 "identifier": "http://example.com/publication"
 ```
 
+In addition to this primary identifier, it <strong class="rfc">may</strong> also provide alternate identifiers using `altIdentifier`.
+
+This element, can contain one or more alternate identifiers where each value is either a:
+
+* URI
+* or an Identifier Object where `scheme` identifies the identifier scheme using an URI and `value` contains the alternate identifier
+
+```json
+"metadata": {
+  "identifier": "urn:isbn:9780679760801",
+  "altIdentifier": [
+    "https://viaf.org/viaf/175580487/",
+    "https://example.com/identifer/12345",
+    {
+      "value": "123456789",
+      "scheme": "https://example.com/identifierScheme"
+    }
+  ]
+}
+```
 
 ## Contributors
 
@@ -76,9 +96,9 @@ Each element can also contain multiple contributors using a simple array:
 "artist": ["Shawn McManus", "Colleen Doran", "Bryan Talbot"]
 ```
 
-In addition to a simple string representation, each contributor can also be represented using an object using the following elements: `name`, `sortAs` and `identifier`.
+In addition to a simple string representation, each contributor <strong class="rfc">may</strong> also be represented using an object using the following elements: `name`, `sortAs` and `identifier`.
 
-When an object is used, it must contain at least `name`. 
+When an object is used, it <strong class="rfc">must</strong> contain at least `name`. 
 
 It behaves like the `title` element and allows either a simple strings, or representations in multiple languages and scripts of a contributor's name:
 
@@ -92,7 +112,7 @@ It behaves like the `title` element and allows either a simple strings, or repre
 }
 ```
 
-The contributor object may also contain a `sortAs` element to provide a single sortable string, used by a client to organize a collection of publications:
+Each object <strong class="rfc">may</strong> also contain a `sortAs` element to provide a single sortable string, used by a client to organize a collection of publications:
 
 ```json
 "author": {
@@ -101,7 +121,7 @@ The contributor object may also contain a `sortAs` element to provide a single s
 }
 ```
 
-Finally, the object may also contain an `identifier`. The `identifier` must be a URI.
+Each object <strong class="rfc">may</strong> also contain an `identifier`. The `identifier` must be a URI.
 
 ISNI (http://isni.org) is the preferred authority, but other sources may also be used:
 
@@ -113,10 +133,23 @@ ISNI (http://isni.org) is the preferred authority, but other sources may also be
 }
 ```
 
-If none of the elements available are specific enough, a `contributor` element <span class="rfc">may</span> be used instead. 
+Finally, each object <strong class="rfc">may</strong> also contain alternate identifiers using the same object defined in the [identifier section](#identifier) of this document.
 
-The `contributor` element should be used with an object that contains a `role`. 
-All values for the `role` element should be based on [MARC relator codes](https://www.loc.gov/marc/relators/relaterm.html): 
+```json
+"author": {
+  "name": "Mikhail Bulgakov",
+  "identifier": "https://isni.org/isni/000000012144993X",
+  "altIdentifier": [
+    "http://viaf.org/viaf/99836700",
+    "http://id.loc.gov/authorities/n79056735"
+  ]
+}
+```
+
+If none of the elements available are fit to identify a given contributor's role, a `contributor` element <span class="rfc">may</span> be used instead. 
+
+The `contributor` element <strong class="rfc">should</strong> be used with an object that contains a `role`. 
+All values for the `role` element <strong class="rfc">should</strong> be based on [MARC relator codes](https://www.loc.gov/marc/relators/relaterm.html): 
 
 ```json
 "contributor": {
@@ -160,7 +193,7 @@ The most straightforward expression is through a simple string:
 "imprint": "World Literature"
 ```
 
-This element also allows a more complex representation using an object and the following elements: `name`, `sortAs`, `identifier`. The semantics and syntax are identical to contributors:
+This element also allows a more complex representation using an object and the following elements: `name`, `sortAs`, `identifier` and `altIdentifier`. The semantics and syntax are identical to contributors:
 
 ```json
 "publisher": {
@@ -250,7 +283,7 @@ A Web Publication Manifest <span class="rfc">may</span> indicate that it belongs
 }
 ```
 
-In order to provide more information about a specific collection/series, an object can also be used instead of a string.
+In order to provide more information about a specific collection/series, an object <strong class="rfc">may</strong> also be used instead of a string.
 
 To provide a name and a sortable string, `collection` and `series` support both `name` and `sortAs`:
 
@@ -263,8 +296,7 @@ To provide a name and a sortable string, `collection` and `series` support both 
 }
 ```
 
-A collection/series can also have an identifier, provided using the `identifier`
-element. The identifier must be a URI:
+A collection/series <strong class="rfc">may</strong> also contain an identifier, provided using the `identifier` element. The identifier <strong class="rfc">must</strong> be a URI:
 
 ```json
 "belongsTo": {
@@ -275,6 +307,8 @@ element. The identifier must be a URI:
   }
 }
 ```
+
+It <strong class="rfc">may</strong> also contain alternate identifiers using the same object defined in the [identifier section](#identifier) of this document.
 
 Finally, series/collection can be ordered. To provide the position of the current publication in a series/collection, the `position` element can be used.
 

--- a/schema/altIdentifier.schema.json
+++ b/schema/altIdentifier.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://readium.org/webpub-manifest/schema/altIdentifier.schema.json",
+  "title": "Alternate Identifiers",
+  "type": "array",
+  "items": {
+    "anyOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            },
+            "scheme": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
+  },
+  "minItems": 1
+}

--- a/schema/contributor-object.schema.json
+++ b/schema/contributor-object.schema.json
@@ -26,6 +26,9 @@
       "type": "string",
       "format": "uri"
     },
+    "altIdentifier": {
+      "$ref": "altIdentifier.schema.json"
+    },
     "sortAs": {
       "type": "string"
     },

--- a/schema/metadata.schema.json
+++ b/schema/metadata.schema.json
@@ -4,10 +4,6 @@
   "title": "Metadata",
   "type": "object",
   "properties": {
-    "identifier": {
-      "type": "string",
-      "format": "uri"
-    },
     "@type": {
       "type": "string",
       "format": "uri"
@@ -31,6 +27,13 @@
     },
     "subtitle": {
       "$ref": "language-map.schema.json"
+    },
+    "identifier": {
+      "type": "string",
+      "format": "uri"
+    },
+    "altIdentifier": {
+      "$ref": "altIdentifier.schema.json"
     },
     "accessibility": {
       "$ref": "a11y.schema.json"


### PR DESCRIPTION
This pull request introduces a new `altIdentifier` to publications, contributors, collections and series, as discussed on https://github.com/opds-community/drafts/discussions/79

I'm currently marking this one as a draft pull request until we figure out how this new element should be mapped (or not) in our JSON LD mapping document.