### PR TITLE
Support for TDM Rep metadata

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -58,6 +58,9 @@
     "series": "http://schema.org/Series",
     "collection": "http://schema.org/Collection",
     "position": "http://schema.org/position",
+    "tdm": "@nest",
+    "reservation": "http://www.w3.org/ns/tdmrep#reservation",
+    "policy": "http://www.w3.org/ns/tdmrep#policy",
     "readingOrder": {
       "@container": "@list",
       "@id": "https://www.w3.org/ns/pub-vocab/manifest#readingOrder"

--- a/contexts/default/README.md
+++ b/contexts/default/README.md
@@ -478,6 +478,24 @@ The `certification` object contains information about the certification process 
 "summary": "The publication is recorded by a professional narrator."
 ```
 
+## Text and data mining
+
+Publications can indicate whether they allow third parties to use their content for text and data mining purposes using the [TDM Rep protocol](https://www.w3.org/community/tdmrep/), as defined in a [W3C Community Group Report](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/).
+
+To do so, they may include a `tdm` object that contains the following properties:
+
+| Property | Values |
+| -------- | ------ |
+| `reservation` | `all` or `none` |
+| `policy` | URI |
+
+For now, `reservation` only allows two values but may be extended in the future to refine the scope of a reservation and its associated policy:
+
+| Value | Description |
+| ----- | ----------- |
+| `all` | All TDM rights are reserved. If a TDM Policy is set, TDM Agents MAY use it to get information on how they can acquire from the rightsholder an authorization to mine the content. |
+| `none` | TDM rights are not reserved. TDM agents can mine the content for TDM purposes without having to contact the rightsholder. |
+
 ## Appendix A - JSON Schema
 
 The default context is implemented in the core JSON Schema for the Readium Web Publication Manifest and should be used as a reference as well.

--- a/schema/metadata.schema.json
+++ b/schema/metadata.schema.json
@@ -145,6 +145,25 @@
           "$ref": "contributor.schema.json"
         }
       }
+    },
+    "tdm": {
+      "type": "object",
+      "required": [
+        "reservation"
+      ],
+      "properties": {
+        "reservation": {
+          "type": "string",
+          "enum": [
+            "all",
+            "none"
+          ]
+        },
+        "policy": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
     }
   },
   "required": [


### PR DESCRIPTION
This PR adds support for the [TDM Rep protocol](https://www.w3.org/community/tdmrep/), as defined in a [W3C Community Group Report](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/):

* New language in the default context document
* JSON Schema
* JSON-LD context to map these properties to the dedicated namespace (http://www.w3.org/ns/tdmrep#)

The first implementation for this metadata has already been completed in the Go toolkit: https://github.com/readium/go-toolkit/commit/7026cb8cfc8cc620ed9fe4f0630293808ae2a42d