### PR TITLE
Added `size` to Link Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ This specification defines the following keys for this JSON object:
 | `properties`  | Properties associated to the linked resource  | [Properties Object](properties.md)  | No |
 | `height`  | Height of the linked resource in pixels | Integer  | No  |
 | `width`  | Width of the linked resource in pixels | Integer | No  |
+| `size`  | Original size of the resource in bytes, prior to any use of encryption or compression in an archive | Integer | No  |
 | `duration`  | Duration of the linked resource in seconds | Float| No  |
 | `bitrate`  | Bit rate of the linked resource in kilobits per second | Float| No  |
 | `language`  | Expected language of the linked resource | One or more [BCP 47 Language Tag](https://tools.ietf.org/html/bcp47) | No  |

--- a/context.jsonld
+++ b/context.jsonld
@@ -81,6 +81,7 @@
     },
     "height": "http://schema.org/height",
     "width": "http://schema.org/width",
+    "size": https://schema.org/contentSize",
     "bitrate": "http://schema.org/bitrate",
     "alternate": {
       "@container": "@set",

--- a/schema/link.schema.json
+++ b/schema/link.schema.json
@@ -62,6 +62,11 @@
       "type": "integer",
       "exclusiveMinimum": 0
     },
+    "size": {
+      "description": "Original size of the resource in bytes, prior to any use of encryption or compression in an archive",
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
     "bitrate": {
       "description": "Bitrate of the linked resource in kbps",
       "type": "number",


### PR DESCRIPTION
This PR closes #107.

As noted in the issue, a separate PR will:

- introduce a new module for dealing with archives (compression method, compressed size, offset in bytes in the archive)
- and deprecate `originalLength` and `compression` in the encryption module