### PR TITLE
Requirement for a `self` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ In addition all publications <strong class="rfc">should</strong> include a `@typ
 
 Links are expressed using the `links` key that contains one or more [Link Objects](#24-the-link-object).
 
-A manifest <strong class="rfc">must</strong> contain at least one link using the `self` relationship where `href` is an absolute URI to the canonical location of the manifest.
+A manifest <strong class="rfc">should</strong> contain at least one link using the `self` relationship where `href` is an absolute URI to the canonical location of the manifest.
 
 *Example 3: Link to the canonical location of a manifest*
 

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -19,29 +19,7 @@
       "items": {
         "$ref": "link.schema.json"
       },
-      "uniqueItems": true,
-      "contains": {
-        "type": "object",
-        "properties": {
-          "rel": {
-            "anyOf": [
-              {
-                "type": "string",
-                "const": "self"
-              },
-              {
-                "type": "array",
-                "contains": {
-                  "const": "self"
-                }
-              }
-            ]
-          }
-        },
-        "required": [
-          "rel"
-        ]
-      }
+      "uniqueItems": true
     },
     "readingOrder": {
       "type": "array",

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -44,7 +44,6 @@
   },
   "required": [
     "metadata",
-    "links",
     "readingOrder"
   ],
   "additionalProperties": {


### PR DESCRIPTION
We've had quite a few discussions over the years about the requirement for a `self` link in every publication (see for example #29).

For now, this is a draft PR where:

- the requirement has been dropped from the main document (from a "**must**" to a "**should**")
- and the corresponding requirement has been dropped from our JSON Schema

I'm not entirely convinced that we can do much better than that right now, but I'm open to the idea of adding another statement in the packaging document ("**must not**").

