### PR TITLE
Added LCC and LCSH subject schemes

### DIFF
--- a/contexts/default/README.md
+++ b/contexts/default/README.md
@@ -298,6 +298,8 @@ This document identifies the following subject schemes along with a recommended 
 | BIC | <https://bic.org.uk/> |
 | BISAC | <https://www.bisg.org/#bisac> |
 | CLIL | <http://clil.org/> |
+| LCC | <http://purl.org/dc/terms/LCC> |
+| LCSH | <http://purl.org/dc/terms/LCSH> |
 | Thema | <https://ns.editeur.org/thema/> |
 
 


### PR DESCRIPTION
This reflects the recent addition of these schemes in Project Gutenberg's OPDS 2.0 feed.